### PR TITLE
Fix skip when --aws-prefix is defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,14 +46,15 @@ function copy (options) {
     .on('error', log.s3.error)
 
   function transfer (file, enc, callback) {
-    s3.headObject({ Key: file.name }, function (err, object) {
+    const dest = options.aws.prefix ? `${options.aws.prefix}/${file.name}` : file.name
+    s3.headObject({ Key: dest }, function (err, object) {
       if (err && err.code !== 'NotFound') return callback(err)
 
       if (object) {
-        log.s3.debug({ message: 'head', object, filename: file.name })
+        log.s3.debug({ message: 'head', object, filename: dest })
 
         if (Number(file.contentLength) === Number(object.ContentLength)) {
-          log.s3.debug({ message: 'skip', filename: file.name })
+          log.s3.debug({ message: 'skip', filename: dest })
           return callback(null)
         }
       }
@@ -62,8 +63,7 @@ function copy (options) {
         delay: 1000
       })
 
-      const key = options.aws.prefix ? `${options.aws.prefix}/${file.name}` : file.name
-      s3.upload({ Key: key, Body: stream }, callback)
+      s3.upload({ Key: dest, Body: stream }, callback)
     })
   }
 


### PR DESCRIPTION
This commit fixes an issue when options.aws.prefix is defined,
s3.headObject will check the wrong path for contentLength
check.