### PR TITLE
Downgrade meow to non-ESM version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "azure-blob-list-stream": "^2.0.0",
     "azure-storage": "^2.10.3",
     "bole": "^4.0.0",
-    "meow": "^10.0.0",
+    "meow": "^9.0.0",
     "ora": "^5.1.0",
     "queue": "^6.0.1",
     "retry-stream-proxy": "~0.2.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://www.bendrucker.me"
   },
   "scripts": {
-    "test": "standard && tape test.js"
+    "test": "standard && tape test.js && node cli.js --help"
   },
   "keywords": [
     "batch",


### PR DESCRIPTION
Downgrades `meow` to a version that does not require ESM.

Closes #44, Closes #45