### PR TITLE
Auto-merge Dependabot patch/minor updates monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
+    interval: monthly
     time: "13:00"
+  cooldown:
+    default-days: 30
   open-pull-requests-limit: 10

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,23 @@
+name: dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Dependabot PRs had piled up because every update needed a manual merge. This moves npm updates to a monthly cadence, holds back anything released in the last 30 days, and auto-merges the low-risk ones so the backlog stops accumulating.

## Changes

- `dependabot.yml`: daily → monthly, plus `cooldown.default-days: 30` so only dependencies that have been published for at least a month are proposed. New releases often ship follow-up patches in their first weeks; the cooldown lets that settle before we take the bump.
- `dependabot-auto-merge.yml`: enables auto-merge on Dependabot **patch and minor** PRs after CI passes. Major bumps are left out deliberately and stay open for manual review. CI passing doesn't prove a major is safe at runtime, and we just saw `eslint` 10 break the build (`neostandard` still pins `eslint@^9`).

The workflow follows GitHub's documented pattern: `on: pull_request` with an elevated `permissions` block and `dependabot/fetch-metadata` to read the update type. It calls `gh pr merge --auto --squash`, matching the repo's squash-merge history.

## Repo config applied out-of-band

Auto-merge needs GitHub configuration that can't live in this diff. Both are already applied via the API:

- **`Allow auto-merge`** enabled on the repository.
- A **`master` branch ruleset** (active) requiring a pull request plus the `build (22)` and `build (24)` checks, blocking force-push and deletion. Required-review count is 0 so Dependabot's auto-merge can proceed, and repo-admin keeps a bypass for manual overrides.

The required checks are what `--auto` waits on, so the ruleset is load-bearing for the auto-merge to be safe rather than cosmetic.

## Verification

This PR is itself gated by the new ruleset, so it can't merge until `build (22)` and `build (24)` pass. That doubles as a live check that the required-checks wiring is correct.
